### PR TITLE
Bump security patch level to 2018-04-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -131,7 +131,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2018-03-05
+    PLATFORM_SECURITY_PATCH := 2018-04-05
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
CVEs fixed in this topic:
CVE-2017-13267
CVE-2017-13274
CVE-2017-13276
CVE-2017-13277
CVE-2017-13278
CVE-2017-13279
CVE-2017-13280
CVE-2017-13282
CVE-2017-13283
CVE-2017-13284
CVE-2017-13285
CVE-2017-13287
CVE-2017-13289
CVE-2017-13290
CVE-2017-13291
CVE-2017-13294
CVE-2017-13295
CVE-2017-13296
CVE-2017-13297
CVE-2017-13298
CVE-2017-13299

CVEs not affecting 14.1:
CVE-2017-13275 8.0/8.1 only
CVE-2017-13281 8.0/8.1 only
CVE-2017-13286 8.0/8.1 only
CVE-2017-13288 8.0/8.1 only
CVE-2017-13301 8.0 only
CVE-2017-13302 8.0 only

Change-Id: Ia0e6e332e86133edd028253a542d1148eaa739a5