### PR TITLE
Bump security patch level to 2018-05-05

### DIFF
--- a/core/version_defaults.mk
+++ b/core/version_defaults.mk
@@ -131,7 +131,7 @@ ifeq "" "$(PLATFORM_SECURITY_PATCH)"
     #  It must be of the form "YYYY-MM-DD" on production devices.
     #  It must match one of the Android Security Patch Level strings of the Public Security Bulletins.
     #  If there is no $PLATFORM_SECURITY_PATCH set, keep it empty.
-    PLATFORM_SECURITY_PATCH := 2018-04-05
+    PLATFORM_SECURITY_PATCH := 2018-05-05
 endif
 
 ifeq "" "$(PLATFORM_BASE_OS)"


### PR DESCRIPTION
Implemented patches:
CVE-2017-13310
CVE-2017-13311
CVE-2017-13313
CVE-2017-13314
CVE-2017-13315
CVE-2017-13316
CVE-2017-13319
CVE-2017-13320
CVE-2017-13323
CVE-2017-13322

Not affecting Android 7.1:
CVE-2017-13309
CVE-2017-13312
CVE-2017-13317
CVE-2017-13318
CVE-2017-13321

Change-Id: Iafe1c76776831912960dfa34cd42b57cff45afeb